### PR TITLE
Keep ticket timestamp updated

### DIFF
--- a/app/src/main/java/com/example/busticket/ui/AdminPanel.kt
+++ b/app/src/main/java/com/example/busticket/ui/AdminPanel.kt
@@ -1,10 +1,8 @@
 package com.example.busticket.ui
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Button
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/app/src/main/java/com/example/busticket/ui/TicketApp.kt
+++ b/app/src/main/java/com/example/busticket/ui/TicketApp.kt
@@ -41,4 +41,3 @@ fun TicketApp() {
     }
 }
 
-// TODO: Implement AdminPanel, UserPanel, TicketView composables

--- a/app/src/main/java/com/example/busticket/ui/TicketView.kt
+++ b/app/src/main/java/com/example/busticket/ui/TicketView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -30,15 +29,15 @@ import java.util.*
 fun TicketView(zone: Int, color: Color) {
     var showQr by remember { mutableStateOf(false) }
     var timeLeft by remember { mutableStateOf(8 * 60 * 60 * 1000L) } // 8 hours in ms
+    var currentTime by remember { mutableStateOf(System.currentTimeMillis()) }
     val formatter = remember { SimpleDateFormat("EEE, MMM d, hh:mm:ss a", Locale.getDefault()) }
-    val now = remember { Date() }
-    val expiry = remember { Date(now.time + timeLeft) }
 
     // Timer
     LaunchedEffect(Unit) {
         while (timeLeft > 0) {
             delay(1000)
             timeLeft -= 1000
+            currentTime += 1000
         }
     }
 
@@ -83,7 +82,7 @@ fun TicketView(zone: Int, color: Color) {
             Text("BUS INTERSTATE PASS", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.White)
             Text("$zone ZONES", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.White)
             Spacer(Modifier.height(8.dp))
-            Text(formatter.format(now), color = Color.White, fontSize = 14.sp)
+            Text(formatter.format(Date(currentTime)), color = Color.White, fontSize = 14.sp)
             Text("Expires in", color = Color.White, fontSize = 12.sp)
             val hours = (timeLeft / (1000 * 60 * 60)).toInt()
             val minutes = ((timeLeft / (1000 * 60)) % 60).toInt()


### PR DESCRIPTION
## Summary
- Update timer logic so the ticket's displayed timestamp advances with the countdown
- Clean up unused imports in the admin panel

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4fcaa8b08327bbf0c855bcae9bc2