### PR TITLE
Specify version for activity-compose dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     // Core and Lifecycle dependencies
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
-    implementation "androidx.activity:activity-compose"
+    implementation "androidx.activity:activity-compose:1.8.2"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2"
 
     // Compose dependencies (versions handled by BOM)


### PR DESCRIPTION
## Summary
- pin androidx.activity:activity-compose to version 1.8.2 in app module

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5cd667fc8327b2757937c9e75d07